### PR TITLE
Httprouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,16 @@ This phase optimizes for **clarity, maintainability, and performance** over conv
 
 ## Current scope
 
-- `net/http` + a lightweight router (e.g., `chi` or `httprouter`)
+- `net/http` + `httprouter`
 - Simple request/response flow and basic middleware (logging and recovery)
 - Health check endpoint and one example resource
 - Clear project layout
+
+---
+
+### Router
+
+`net/http` + `httprouter` — escolha orientada a **muitas rotas**, **baixa alocação** e **patterns de rota expressivos** (ex.: `/v1/users/:id`, `/*filepath`)
 
 ---
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
+
 	"github.com/re-miranda/go_http_api/internal/v1/httpx"
 )
 
@@ -9,5 +11,10 @@ var config = flag.String("config", "Default", "Path to server config file")
 
 func main(){
 	flag.Parse()
-	httpx.Router(*config)
+
+	done := make(chan string)
+	go httpx.Router(*config, done)
+	fmt.Println(<-done)
+
+	for {}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/re-miranda/go_http_api
 
 go 1.25.0
+
+require github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/internal/v1/httpx/handlers/error_handler.go
+++ b/internal/v1/httpx/handlers/error_handler.go
@@ -10,7 +10,7 @@ type APIError struct {
     Details interface{} `json:"details,omitempty"`
 }
 
-func	APIerrorJSON(w http.ResponseWriter, status string, code int, details...any) {
+func	APIErrorJSON(w http.ResponseWriter, status string, code int, details...any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	if len(details) != 0 {

--- a/internal/v1/httpx/handlers/healthz_handler.go
+++ b/internal/v1/httpx/handlers/healthz_handler.go
@@ -1,9 +1,12 @@
 package handlers
 
-import "net/http"
-import "encoding/json"
+import (
+	"net/http"
+	"encoding/json"
+	"github.com/julienschmidt/httprouter"
+)
 
-func HealthzHandler (w http.ResponseWriter, r *http.Request) {
+func HealthzHandler (w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})

--- a/internal/v1/httpx/handlers/ping_handler.go
+++ b/internal/v1/httpx/handlers/ping_handler.go
@@ -1,8 +1,11 @@
 package handlers
 
-import "net/http"
-import "fmt"
+import (
+	"net/http"
+	"fmt"
+	"github.com/julienschmidt/httprouter"
+)
 
-func PingHandler (w http.ResponseWriter, r *http.Request) {
+func PingHandler (w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	fmt.Fprintf(w, "pong")
 }

--- a/internal/v1/httpx/handlers/reverse_handler.go
+++ b/internal/v1/httpx/handlers/reverse_handler.go
@@ -11,7 +11,7 @@ func ReverseHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	defer r.Body.Close()
 
 	if r.Method != http.MethodPost {
-		APIerrorJSON(w, "Method not allowed", http.StatusMethodNotAllowed)
+		APIErrorJSON(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
@@ -24,7 +24,7 @@ func ReverseHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params)
 	var m Message
 	err := dec.Decode(&m)
 	if err != nil {
-		APIerrorJSON(w, "Bad Request", http.StatusBadRequest, err.Error())
+		APIErrorJSON(w, "Bad Request", http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/v1/httpx/handlers/reverse_handler.go
+++ b/internal/v1/httpx/handlers/reverse_handler.go
@@ -4,9 +4,10 @@ import (
 	"net/http"
 	"encoding/json"
 	"github.com/re-miranda/go_http_api/internal/v1/core"
+	"github.com/julienschmidt/httprouter"
 )
 
-func ReverseHandler(w http.ResponseWriter, r *http.Request) {
+func ReverseHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	defer r.Body.Close()
 
 	if r.Method != http.MethodPost {

--- a/internal/v1/httpx/handlers/reverse_handler_test.go
+++ b/internal/v1/httpx/handlers/reverse_handler_test.go
@@ -71,7 +71,7 @@ func TestReverseHandler(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			ReverseHandler(rr, req)
+			ReverseHandler(rr, req, nil)
 
 			if rr.Code != tt.expectedStatus {
 				t.Errorf("Expected status code %d, got %d", tt.expectedStatus, rr.Code)

--- a/internal/v1/httpx/router.go
+++ b/internal/v1/httpx/router.go
@@ -3,22 +3,18 @@ package httpx
 import (
 	"fmt"
 	"net/http"
+	"github.com/julienschmidt/httprouter"
 	"github.com/re-miranda/go_http_api/internal/v1/httpx/handlers"
 )
 
 func Router(config string) error{
 	fmt.Println(config)
 
-	mux := http.NewServeMux()
+	router := httprouter.New()
+	router.GET("/healthz", handlers.HealthzHandler)
+	router.GET("/v1/ping", handlers.PingHandler)
+	router.POST("/v1/reverse", handlers.ReverseHandler)
 
-	mux.HandleFunc("/healthz", handlers.HealthzHandler)
-	mux.HandleFunc("/v1/ping", handlers.PingHandler)
-	mux.HandleFunc("/v1/reverse", handlers.ReverseHandler)
-
-	srv := http.Server {
-		Addr: ":8080",
-		Handler: mux,
-	}
 	fmt.Println("Server is starting")
-	return srv.ListenAndServe()
+	return http.ListenAndServe(":8080", router)
 }

--- a/internal/v1/httpx/router.go
+++ b/internal/v1/httpx/router.go
@@ -3,18 +3,29 @@ package httpx
 import (
 	"fmt"
 	"net/http"
+	"time"
 	"github.com/julienschmidt/httprouter"
 	"github.com/re-miranda/go_http_api/internal/v1/httpx/handlers"
 )
 
-func Router(config string) error{
+func Router(config string, done chan string) error{
 	fmt.Println(config)
 
-	router := httprouter.New()
-	router.GET("/healthz", handlers.HealthzHandler)
-	router.GET("/v1/ping", handlers.PingHandler)
-	router.POST("/v1/reverse", handlers.ReverseHandler)
+	// Create and set multiplexer (router)
+	mux := httprouter.New()
+	mux.GET("/healthz", handlers.HealthzHandler)
+	mux.GET("/v1/ping", handlers.PingHandler)
+	mux.POST("/v1/reverse", handlers.ReverseHandler)
 
-	fmt.Println("Server is starting")
-	return http.ListenAndServe(":8080", router)
+	// Create server
+	srv := &http.Server{
+		Addr: ":8080",
+		Handler: mux,
+		ReadTimeout: 5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout: 60 * time.Second,
+	}
+
+	done <- "Server is starting"
+	return srv.ListenAndServe()
 }


### PR DESCRIPTION
feat(router): migrate to julienschmidt/httprouter for perf and rich route patterns

Why
- Many routes + low allocs
- Parametrized paths (e.g., /v1/users/:id) and wildcard patterns

Testing
- make test passes